### PR TITLE
Normalize the 2019 Jekyll-to-Hugo post URL

### DIFF
--- a/content/posts/2019-06-19-from-jekyll-to-hugo.markdown
+++ b/content/posts/2019-06-19-from-jekyll-to-hugo.markdown
@@ -2,6 +2,9 @@
 layout: post
 title:  "From Jekyll to Hugo"
 date:   2019-06-19 07:38:42 -0700
+url: posts/2019/06/19/from-jekyll-to-hugo/
+aliases:
+  - /posts/2019/06/From-Jekyll-to-Hugo/
 tags:
 - jekyll
 - hugo


### PR DESCRIPTION
## Summary

Fixes the outlier URL on \`content/posts/2019-06-19-from-jekyll-to-hugo.markdown\`. Every other post in the repo has an explicit \`url:\` front-matter field pointing at a lowercase-with-day slug (\`posts/:year/:month/:day/:slug/\`). The 2019 post didn't, so it fell back to Hugo's auto-generated permalink — which, combined with \`disablePathToLower: true\` in \`config.yaml\`, produced the mixed-case, no-day URL:

\`\`\`
/posts/2019/06/From-Jekyll-to-Hugo/
\`\`\`

## Fix

Add an explicit \`url:\` matching the convention of the other posts, plus an \`aliases:\` entry for backward compatibility:

\`\`\`yaml
url: posts/2019/06/19/from-jekyll-to-hugo/
aliases:
  - /posts/2019/06/From-Jekyll-to-Hugo/
\`\`\`

Hugo generates an HTML meta-refresh redirect at the alias path, so inbound links (search indexes, external blog references, etc.) to the old URL land on the canonical URL instead of 404-ing.

## Test plan

Verified locally (\`hugo --destination /tmp/…\`):

- \`/posts/2019/06/19/from-jekyll-to-hugo/index.html\` — the new canonical page.
- \`/posts/2019/06/From-Jekyll-to-Hugo/index.html\` — contains \`<meta http-equiv="refresh" content="0; url=https://harringa.com/posts/2019/06/19/from-jekyll-to-hugo/">\`.
- Home page "Read more…" link for the post points at the new URL.

## Follow-up

Once [bota-hugo-theme#11](https://github.com/justinharringa/bota-hugo-theme/pull/11) merges (fixes the doubled \`<title>\` on the home page), a tiny follow-up PR will bump the submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)