### PR TITLE
Disable Renovate's bundler manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
     ":dependencyDashboard",
     ":semanticCommits"
   ],
+  "bundler": {
+    "enabled": false
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Renovate's bundler manager has been firing on this repo and failing — two runs on 2026-05-08 (\`bundler in /. for nokogiri - Update\`) completed with status \"failure\" but produced no PR. The repo has had no \`Gemfile\` since the Jekyll-to-Hugo migration in commit \`cfcfef6\`, so the bundler manager has nothing to actually update; it's just noise in the runs history.

## Change

One block added to \`.github/renovate.json\`:

\`\`\`json
\"bundler\": {
  \"enabled\": false
}
\`\`\`

## Reversal

If a Ruby dependency ever returns to this repo, flip \`enabled\` back to \`true\`.