### PR TITLE
chore(deps): update Hugo to v0.162.1 and allow text/html content

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # renovate: datasource=github-releases depName=gohugoio/hugo extractVersion=^v(?<version>.+)$
-      HUGO_VERSION: 0.161.1
+      HUGO_VERSION: 0.162.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # renovate: datasource=github-releases depName=gohugoio/hugo extractVersion=^v(?<version>.+)$
-      HUGO_VERSION: 0.161.1
+      HUGO_VERSION: 0.162.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,12 @@ disqusShortname: "harringa"
 
 theme: bota
 
+# Hugo 0.162.0 disallows text/html content files by default via security.allowContent.
+# This site has hand-authored .html posts (migrated from Blogger), so opt back in.
+security:
+  allowContent:
+    - '.*'
+
 markup:
   goldmark:
     renderer:


### PR DESCRIPTION
Supersedes #55.

## What
- Bumps Hugo `0.161.1` → `0.162.1` in both CI workflows (carried over from #55).
- Adds a `security.allowContent` policy to `config.yaml` so the build still passes on Hugo 0.162.x.

## Why
Hugo 0.162.0 introduced a new `security.allowContent` policy that **denies `text/html` content files by default** (`'! ^text/html$'`). This site has three hand-authored `.html` posts under `content/posts/` (migrated from Blogger):

- `content/posts/2011-05-21-i-didnt-make-first-cut-of-rapture.html`
- `content/posts/2011-05-23-best-phones-for-each-carrier-in-united.html`
- `content/posts/2011-05-26-chromebooks-and-tablets-and-phones-oh.html`

Without opting back in, the `build` check on #55 fails. The fix:

```yaml
security:
  allowContent:
    - '.*'
```

This is the documented opt-back-in. `'.*'` (rather than a narrower `'^text/html$'`) preserves all other content media types as well.

## Notes
- The posts are static, hand-authored content under the author's control, so the XSS-sink concern behind the new default doesn't apply here. The site already sets `markup.goldmark.renderer.unsafe: true`.
- Once this merges, #55 can be closed.

https://claude.ai/code/session_011ASbdjfoZLjYMwsEQpeabZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011ASbdjfoZLjYMwsEQpeabZ)_